### PR TITLE
Add updates/overwites to tests

### DIFF
--- a/kvs.cabal
+++ b/kvs.cabal
@@ -18,6 +18,7 @@ common com
     RecordWildCards
     OverloadedStrings
     DoAndIfThenElse
+    TupleSections
   build-depends:
     , base
     , unix >= 2.7.1

--- a/test/CommitLogSpec.hs
+++ b/test/CommitLogSpec.hs
@@ -4,12 +4,13 @@ import BinIO (kvFold)
 import qualified CommitLog
 import Common
 import Data.Foldable (for_)
+import qualified Memtable
 import Test.Hspec (SpecWith, describe, it)
 import Test.QuickCheck (Property, arbitrary, generate, property, withMaxSuccess)
 import Test.QuickCheck.Monadic (assert, monadicIO, run)
 import Types hiding (commitLogPath)
 
-buildCommitLog :: IO ([(Key, Value)], FilePath)
+buildCommitLog :: IO ([Entry], FilePath)
 buildCommitLog = do
   commitLogPath <- mkTempFilePath "commitlog" ".bin"
   (_, commitLog) <- CommitLog.resume commitLogPath
@@ -22,7 +23,10 @@ prop_roundtrip :: Property
 prop_roundtrip = monadicIO $ do
   (input, commitLogPath) <- run buildCommitLog
   entriesOut <- run $ reverse <$> kvFold commitLogPath (:) []
+  (memtable, _) <- run $ CommitLog.resume commitLogPath
+  memtableEntries <- run $ Memtable.entries memtable
   assert $ input == entriesOut
+  assert $ latestEntries input == memtableEntries
 
 tests :: SpecWith ()
 tests = describe "CommitLog" $ do

--- a/test/Common.hs
+++ b/test/Common.hs
@@ -3,15 +3,34 @@
 module Common where
 
 import Data.Function (on)
-import Data.List (nubBy)
+import Data.List (foldl', nubBy, sortOn)
+import Data.Traversable (for)
 import Data.Word (Word64)
 import Orphans
 import System.CPUTime (getCPUTime)
 import Test.QuickCheck (Gen, arbitrary, generate)
-import Types (Key, Value)
+import Test.QuickCheck.Gen (sublistOf)
+import Types
 
-entriesUniqueByKey :: Gen [(Key, Value)]
+entriesUniqueByKey :: Gen [Entry]
 entriesUniqueByKey = nubBy ((==) `on` fst) <$> arbitrary
+
+entriesWithDuplicateKeys :: Gen [Entry]
+entriesWithDuplicateKeys = do
+  entries <- arbitrary
+  dups <- sublistOf entries
+  updatedEntries <- for dups $ \(k, _) -> (k,) <$> arbitrary
+  pure $ entries ++ updatedEntries
+
+latestEntries :: [Entry] -> [Entry]
+latestEntries = reverse . foldl' merge [] . sortOn fst
+  where
+    merge :: [Entry] -> Entry -> [Entry]
+    merge (prev@(key, _) : rest) next@(key', _) =
+      if key == key'
+        then next : rest
+        else next : prev : rest
+    merge [] kv = [kv]
 
 mkTempFilePath :: String -> String -> IO FilePath
 mkTempFilePath prefix affix = do

--- a/test/RBTreeSpec.hs
+++ b/test/RBTreeSpec.hs
@@ -3,35 +3,33 @@ module RBTreeSpec where
 import Common
 import Data.Foldable (for_)
 import Data.List (sortOn)
-import Data.Maybe (fromJust)
-import Data.Traversable (for)
 import RBTree (RBTree)
 import qualified RBTree
 import Test.Hspec (SpecWith, describe, it)
-import Test.QuickCheck (Property, generate, property, withMaxSuccess)
+import Test.QuickCheck (Gen, Property, generate, property, withMaxSuccess)
 import Test.QuickCheck.Monadic (assert, monadicIO, run)
 import Types
 
-buildTree :: IO ([(Key, Value)], RBTree)
-buildTree = do
+buildTree :: Gen [Entry] -> IO ([(Key, Value)], RBTree)
+buildTree input = do
   tree <- RBTree.empty
-  input <- generate entriesUniqueByKey
-  for_ input (uncurry $ RBTree.insert tree)
-  pure (input, tree)
+  input' <- generate input
+  for_ input' (uncurry $ RBTree.insert tree)
+  pure (input', tree)
 
 prop_order :: Property
 prop_order = monadicIO $ do
-  (input, tree) <- run buildTree
+  (input, tree) <- run $ buildTree entriesUniqueByKey
   output <- run $ RBTree.toList tree
   let sortedInput = sortOn fst input
   assert $ output == sortedInput
 
 prop_association :: Property
 prop_association = monadicIO $ do
-  (input, tree) <- run buildTree
-  valuesOut <- run $ for input (fmap fromJust . RBTree.search tree . fst)
-  let valuesIn = snd <$> input
-  assert $ valuesIn == valuesOut
+  (input, tree) <- run $ buildTree entriesWithDuplicateKeys
+  entriesOut <- run $ RBTree.toList tree
+  let entriesIn = latestEntries input
+  assert $ entriesIn == entriesOut
 
 tests :: SpecWith ()
 tests = describe "RBTree" $ do


### PR DESCRIPTION
The tests assumed uniques entries, since it was easier at the time. This PR just adds some helpers to make comparing the _latest_ entries easier.