### PR TITLE
Make Memtable tests more strict

### DIFF
--- a/kvs.cabal
+++ b/kvs.cabal
@@ -19,6 +19,7 @@ common com
     OverloadedStrings
     DoAndIfThenElse
     TupleSections
+    LambdaCase
   build-depends:
     , base
     , unix >= 2.7.1

--- a/kvs.cabal
+++ b/kvs.cabal
@@ -59,6 +59,5 @@ test-suite test
     src
   build-depends:
     , hspec
-    , hspec-expectations
     , QuickCheck
     , quickcheck-instances

--- a/kvs.cabal
+++ b/kvs.cabal
@@ -59,5 +59,6 @@ test-suite test
     src
   build-depends:
     , hspec
+    , hspec-expectations
     , QuickCheck
     , quickcheck-instances

--- a/test/MemtableSpec.hs
+++ b/test/MemtableSpec.hs
@@ -32,7 +32,7 @@ prop_minByteCount = monadicIO $ do
   (input, memtable) <- run buildMemtable
   let inputSize = sum $ entrySize <$> input
   byteCount <- run $ Memtable.approximateBytes memtable
-  assert $ byteCount >= inputSize
+  assert $ byteCount == inputSize
 
 prop_association :: Property
 prop_association = monadicIO $ do

--- a/test/MemtableSpec.hs
+++ b/test/MemtableSpec.hs
@@ -1,21 +1,15 @@
 module MemtableSpec where
 
 import Common
-import Control.Monad (replicateM_)
-import Control.Monad.IO.Class (liftIO)
 import qualified Data.ByteString as BS
 import Data.Coerce (coerce)
 import Data.Foldable (for_)
 import Memtable (Memtable)
 import qualified Memtable
 import Test.Hspec (SpecWith, describe, it)
-import Test.Hspec.Expectations (shouldBe)
 import Test.QuickCheck (Property, generate, property, withMaxSuccess)
 import Test.QuickCheck.Monadic (assert, monadicIO, run)
 import Types
-
-approximateBytesThreshold :: Int
-approximateBytesThreshold = 1024
 
 buildMemtable :: IO ([Entry], Memtable)
 buildMemtable = do
@@ -36,7 +30,7 @@ prop_minByteCount = monadicIO $ do
   (input, memtable) <- run buildMemtable
   let inputSize = sum $ entrySize <$> latestEntries input
   byteCount <- run $ Memtable.approximateBytes memtable
-  assert $ abs (byteCount - inputSize) <= approximateBytesThreshold
+  assert $ byteCount == inputSize
 
 prop_association :: Property
 prop_association = monadicIO $ do
@@ -50,12 +44,3 @@ tests = describe "Memtable" $ do
     property $ withMaxSuccess 10000 prop_minByteCount
   it "get returns the correct values" $ do
     property $ withMaxSuccess 10000 prop_association
-  it "does not count duplicate inserts" $ do
-    let emptyEntry = (Key "A", Tombstone)
-        expectedSize = entrySize emptyEntry
-    byteCount <- liftIO $ do
-      memtable <- Memtable.empty
-      replicateM_ approximateBytesThreshold $
-        uncurry (Memtable.set memtable) emptyEntry
-      Memtable.approximateBytes memtable
-    byteCount `shouldBe` expectedSize

--- a/test/MemtableSpec.hs
+++ b/test/MemtableSpec.hs
@@ -1,14 +1,14 @@
 module MemtableSpec where
 
 import Common
+import Control.Monad.IO.Class (liftIO)
 import qualified Data.ByteString as BS
 import Data.Coerce (coerce)
 import Data.Foldable (for_)
-import Data.Maybe (fromJust)
-import Data.Traversable (for)
 import Memtable (Memtable)
 import qualified Memtable
 import Test.Hspec (SpecWith, describe, it)
+import Test.Hspec.Expectations (shouldBe)
 import Test.QuickCheck (Property, generate, property, withMaxSuccess)
 import Test.QuickCheck.Monadic (assert, monadicIO, run)
 import Types
@@ -19,7 +19,7 @@ approximateBytesThreshold = 1024
 buildMemtable :: IO ([Entry], Memtable)
 buildMemtable = do
   memtable <- Memtable.empty
-  input <- generate entriesUniqueByKey
+  input <- generate entriesWithDuplicateKeys
   for_ input (uncurry $ Memtable.set memtable)
   pure (input, memtable)
 
@@ -33,20 +33,29 @@ entrySize (key, Value valueBytes) = keySize + valueSize
 prop_minByteCount :: Property
 prop_minByteCount = monadicIO $ do
   (input, memtable) <- run buildMemtable
-  let inputSize = sum $ entrySize <$> input
+  let inputSize = sum $ entrySize <$> latestEntries input
   byteCount <- run $ Memtable.approximateBytes memtable
   assert $ abs (byteCount - inputSize) <= approximateBytesThreshold
 
 prop_association :: Property
 prop_association = monadicIO $ do
   (input, memtable) <- run buildMemtable
-  valuesOut <- run $ for input (fmap fromJust . Memtable.get memtable . fst)
-  let valuesIn = snd <$> input
-  assert $ valuesIn == valuesOut
+  valuesOut <- run $ Memtable.entries memtable
+  assert $ latestEntries input == valuesOut
 
 tests :: SpecWith ()
 tests = describe "Memtable" $ do
   it "keeps track of memory usage" $ do
-    property $ withMaxSuccess 10000 prop_minByteCount
+    property $ withMaxSuccess 100000 prop_minByteCount
   it "get returns the correct values" $ do
     property $ withMaxSuccess 10000 prop_association
+  it "does not count duplicate inserts" $ do
+    let emptyEntry = (Key "A", Tombstone)
+        expectedSize = entrySize emptyEntry
+    byteCount <- liftIO $ do
+      memtable <- Memtable.empty
+      for_ [1 .. approximateBytesThreshold] $
+        const $ do
+          uncurry (Memtable.set memtable) emptyEntry
+      Memtable.approximateBytes memtable
+    byteCount `shouldBe` expectedSize

--- a/test/MemtableSpec.hs
+++ b/test/MemtableSpec.hs
@@ -13,6 +13,9 @@ import Test.QuickCheck (Property, generate, property, withMaxSuccess)
 import Test.QuickCheck.Monadic (assert, monadicIO, run)
 import Types
 
+approximateBytesThreshold :: Int
+approximateBytesThreshold = 1024
+
 buildMemtable :: IO ([Entry], Memtable)
 buildMemtable = do
   memtable <- Memtable.empty
@@ -32,7 +35,7 @@ prop_minByteCount = monadicIO $ do
   (input, memtable) <- run buildMemtable
   let inputSize = sum $ entrySize <$> input
   byteCount <- run $ Memtable.approximateBytes memtable
-  assert $ byteCount == inputSize
+  assert $ abs (byteCount - inputSize) <= approximateBytesThreshold
 
 prop_association :: Property
 prop_association = monadicIO $ do


### PR DESCRIPTION
The current implementation of `Memtable` has the potential issue where we may flush small segments to disk. In the pathological case, where someone wrote the same key with a `Tombstone` value repeatedly, we would keep incrementing the approximate byte count. This would result in `Kvs` flushing to disk prematurely.

Instead of doing a `>=` check, ~maybe we can check if the approximate bytes are within some threshold?~ we'll make this more strict for now.