### PR TITLE
Remove unset

### DIFF
--- a/src/CommitLog.hs
+++ b/src/CommitLog.hs
@@ -1,5 +1,5 @@
 module CommitLog
-  ( -- * Common Operations
+  ( -- * Common API
     CommitLog,
     resume,
     set,

--- a/src/CommitLog.hs
+++ b/src/CommitLog.hs
@@ -3,7 +3,6 @@ module CommitLog
     CommitLog,
     resume,
     set,
-    unset,
     purge,
 
     -- * Debugging
@@ -33,12 +32,6 @@ set CommitLog {..} key value =
     writeEntry key value
     sync
 
-unset :: CommitLog -> Key -> IO ()
-unset CommitLog {..} key =
-  withKVWriter' commitLogHandle $ do
-    writeEntry key Tombstone
-    sync
-
 purge :: CommitLog -> IO ()
 purge CommitLog {..} =
   withKVWriter' commitLogHandle BinIO.truncate
@@ -47,10 +40,7 @@ close :: CommitLog -> IO ()
 close CommitLog {..} = hClose commitLogHandle
 
 recoverMemtable :: FilePath -> Memtable -> IO ()
-recoverMemtable commitLogPath memtable = kvIterIO commitLogPath $ uncurry setEntry
-  where
-    setEntry key Tombstone = Memtable.unset memtable key
-    setEntry key value = Memtable.set memtable key value
+recoverMemtable commitLogPath memtable = kvIterIO commitLogPath $ uncurry $ Memtable.set memtable
 
 openCommitLog :: FilePath -> Memtable -> IO Handle
 openCommitLog commitLogPath memtable = do

--- a/src/Kvs.hs
+++ b/src/Kvs.hs
@@ -53,18 +53,6 @@ set k v = do
       when (byteCount >= mtMaxSize) $
         flushMemory kvsData
 
-unset :: Key -> Kvs ()
-unset k = do
-  kvsData@KvsData {..} <- ask
-  lift $
-    RWLock.withWrite rwLock $ do
-      memtable' <- readIORef memtable
-      void $ CommitLog.unset commitLog k
-      void $ Memtable.unset memtable' k
-      byteCount <- Memtable.approximateBytes memtable'
-      when (byteCount >= mtMaxSize) $
-        flushMemory kvsData
-
 flushMemory :: KvsData -> IO ()
 flushMemory KvsData {..} = do
   memtable' <- readIORef memtable

--- a/src/Kvs.hs
+++ b/src/Kvs.hs
@@ -1,19 +1,29 @@
-module Kvs where
+module Kvs
+  ( -- * KVS API
+    Kvs,
+    get,
+    set,
 
-import CommitLog
+    -- * Kvs State
+    KvsData,
+    mkKvsData,
+  )
+where
+
+import CommitLog (CommitLog)
+import qualified CommitLog
 import Control.Applicative ((<|>))
 import Control.Concurrent.ReadWriteLock (RWLock)
 import qualified Control.Concurrent.ReadWriteLock as RWLock
 import Control.Monad.Reader
 import Data.IORef
-import Memtable
+import Memtable (Memtable)
+import qualified Memtable
 import Segments
 import Types
 
 mtMaxSize :: Int
 mtMaxSize = 5000000
-
-type SegmentPath = String
 
 data KvsData = KvsData
   { commitLog :: CommitLog,

--- a/src/Memtable.hs
+++ b/src/Memtable.hs
@@ -2,12 +2,7 @@ module Memtable
   ( -- * Memtable API
     Memtable,
     Memtable.empty,
-
-    -- * Mutation
     set,
-    unset,
-
-    -- * Other
     get,
     entries,
     approximateBytes,
@@ -49,9 +44,6 @@ set Memtable {..} key value = do
       Nothing -> keySize + newValueSize
     atomicAdd ref n = do
       atomicModifyIORef' ref (\n' -> (n' + n, ()))
-
-unset :: Memtable -> Key -> IO ()
-unset memtable key = set memtable key Tombstone
 
 get :: Memtable -> Key -> IO (Maybe Value)
 get Memtable {..} key = do


### PR DESCRIPTION
The `unset` operation is only useful in the REST layer, and introduces unecessary code duplication otherwise.